### PR TITLE
add auth service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ jspm_packages
 .serverless
 
 .webpack
+
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -4260,6 +4260,12 @@
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
       "dev": true
     },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+      "dev": true
+    },
     "download": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/download/-/download-8.0.0.tgz",
@@ -9388,6 +9394,17 @@
             "ansi-regex": "^5.0.0"
           }
         }
+      }
+    },
+    "serverless-dotenv-plugin": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-3.1.0.tgz",
+      "integrity": "sha512-R9Jld4a/hDDd0lHiSq9xQuFlhtfgXqKKmODrYp7115iQ9kgf16SMxZbxJ0Cb9GqL6/4+5GlS42iHxsqv8GxZeQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "dotenv": "^8.2.0",
+        "dotenv-expand": "^5.1.0"
       }
     },
     "serverless-functions-base-path": {

--- a/package.json
+++ b/package.json
@@ -10,23 +10,25 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "aws-sdk": "^2.792.0",
     "@babel/preset-env": "^7.12.1",
+    "aws-sdk": "^2.792.0",
     "aws-sdk-mock": "^5.1.0",
     "babel-jest": "^26.6.1",
     "jest": "^26.6.1",
+    "serverless": "^2.9.0",
+    "serverless-dotenv-plugin": "^3.1.0",
     "serverless-functions-base-path": "^1.0.32",
     "serverless-s3-deploy": "^0.9.0",
     "serverless-webpack": "^5.3.5",
     "ts-jest": "^26.4.3",
     "webpack": "^5.3.2",
-    "serverless": "^2.9.0",
     "webpack-node-externals": "^2.5.2"
   },
   "scripts": {
     "test": "jest",
     "deploy:product-service": "sls deploy -c serverless-product-service.yml",
-    "deploy:import-service": "sls deploy -c serverless-import-service.yml"
+    "deploy:import-service": "sls deploy -c serverless-import-service.yml",
+    "deploy:authorization-service": "sls deploy -c serverless-authorization-service.yml"
   },
   "repository": {
     "type": "git",

--- a/serverless-authorization-service.yml
+++ b/serverless-authorization-service.yml
@@ -1,0 +1,32 @@
+service:
+  name: authorizationservice
+
+plugins:
+  - serverless-dotenv-plugin
+  - serverless-functions-base-path
+  - serverless-webpack
+
+frameworkVersion: "2"
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  profile: node-aws
+  region: ${opt:region, 'us-east-1'}
+  environment:
+    ilyavalasiuk: ${env:ilyavalasiuk}
+
+custom:
+  functionsBasePath: src/authorization-service/handlers
+  webpack:
+    webpackConfig: "./webpack.config.js"
+    includeModules: true
+    keepOutputDirectory: true
+
+functions:
+  - ${file(./serverless/functions/authorization.yml)}
+
+resources:
+  Outputs:
+    authorizationArn:
+      Value: !GetAtt AuthorizationLambdaFunction.Arn

--- a/serverless-import-service.yml
+++ b/serverless-import-service.yml
@@ -44,3 +44,4 @@ functions:
 
 resources:
   - ${file(./serverless/resources/upload-bucket.yml)}
+  - ${file(./serverless/resources/api-gateway-response.yml)}

--- a/serverless/functions/authorization.yml
+++ b/serverless/functions/authorization.yml
@@ -1,0 +1,3 @@
+authorization:
+  name: dev-${self:service.name}-authorization-function
+  handler: authorization/index.handler

--- a/serverless/functions/import.yml
+++ b/serverless/functions/import.yml
@@ -5,6 +5,12 @@ importProductsFile:
     - http:
         path: import
         method: GET
+        cors: true
+        authorizer:
+          arn: ${cf:authorizationservice-dev.authorizationArn}
+          managedExternally: false
+          resultTtlInSeconds: 0
+          identitySource: method.request.header.Authorization
         request:
           parameters:
             querystrings:

--- a/serverless/resources/api-gateway-response.yml
+++ b/serverless/resources/api-gateway-response.yml
@@ -1,0 +1,11 @@
+Resources:
+  GatewayResponseDefault4XX:
+    Type: "AWS::ApiGateway::GatewayResponse"
+    Properties:
+      ResponseParameters:
+        gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+        gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        gatewayresponse.header.Access-Control-Allow-Methods: "'GET,OPTIONS'"
+      ResponseType: DEFAULT_4XX
+      RestApiId:
+        Ref: "ApiGatewayRestApi"

--- a/src/authorization-service/handlers/authorization/index.js
+++ b/src/authorization-service/handlers/authorization/index.js
@@ -1,0 +1,39 @@
+
+const generateResponse = (principalId, effect, resource) => ({
+  principalId,
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Action: "execute-api:Invoke",
+        Effect: effect,
+        Resource: resource
+      }
+    ]
+  }
+})
+
+export const handler = (event, context, callback) => {
+  console.log(event);
+
+  if (event.type !== 'TOKEN') {
+    callback('Error: Token type missed.');
+  }
+
+  const encodedToken = event.authorizationToken.split('Basic ')[1];
+  
+  if (!encodedToken) {
+    callback(null, generateResponse('user', 'Deny', event.methodArn))
+  }
+  
+  const token = Buffer.from(encodedToken, 'base64').toString();
+  const [user, password] = token.split(':');
+
+  console.log(token);
+
+  if (user === 'ilyavalasiuk' && password === process.env['ilyavalasiuk']) {
+    callback(null, generateResponse('user', 'Allow', event.methodArn))
+  } else {
+    callback(null, generateResponse('user', 'Deny', event.methodArn))
+  }
+}

--- a/src/utils/api-response.js
+++ b/src/utils/api-response.js
@@ -1,7 +1,8 @@
 const headers = {
-  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization",
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "OPTIONS,GET,POST,PUT"
+  "Access-Control-Allow-Methods": "OPTIONS,GET,POST,PUT",
+  'Access-Control-Allow-Credentials': true
 }
 
 export const createSuccessResponse = (data) => ({


### PR DESCRIPTION
# FE:
* https://d3gc8aipmhoxz.cloudfront.net/
```
// Correct auth token
localStorage.setItem('authorization_token', 'Basic aWx5YXZhbGFzaXVrOlRFU1RfUEFTU1dPUkQ=')

// Incorrect auth toke
localStorage.setItem('authorization_token', 'Basic aWx5YXZhbGFzaXVrOlRFU1RfUEFTU1dPUk22Q=')
localStorage.setItem('authorization_token', '')
```

# Evaluation criteria:
- [x] authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- [x] import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x] update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')

# Additional (optional) tasks:
- [x] Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file - https://github.com/Ilya-Valasiuk/nodejs-aws-fe/commit/3e47d9feb65431906e55052ffe26085d342584b4